### PR TITLE
Require PPA before installing PEAR

### DIFF
--- a/modules/v8js/manifests/extension.pp
+++ b/modules/v8js/manifests/extension.pp
@@ -53,6 +53,10 @@ class v8js::extension(
 	if ! defined( Package['php-pear'] ) {
 		package { 'php-pear':
 			ensure => installed,
+			require => [
+				Apt::Ppa['ppa:ondrej/php'],
+				Package["${php_package}-fpm"],
+			],
 		}
 	}
 

--- a/modules/v8js/manifests/extension.pp
+++ b/modules/v8js/manifests/extension.pp
@@ -52,7 +52,7 @@ class v8js::extension(
 
 	if ! defined( Package['php-pear'] ) {
 		package { 'php-pear':
-			ensure => installed,
+			ensure  => installed,
 			require => [
 				Apt::Ppa['ppa:ondrej/php'],
 				Package["${php_package}-fpm"],


### PR DESCRIPTION
If `php-pear` is installed too early, `1.10.1` is installed, which is incompatible with PHP 7.2. If we declare a dependency on the PPA, this should ensure `1.10.8` is installed instead.

Fixes #23.