### PR TITLE
Fix v8js to 2.1.0

### DIFF
--- a/modules/v8js/manifests/extension.pp
+++ b/modules/v8js/manifests/extension.pp
@@ -72,7 +72,7 @@ class v8js::extension(
 	if ( installed == $package ) {
 		exec { 'pecl install v8js':
 			command => "/bin/echo '/opt/libv8-${v8_version}
-				' | /usr/bin/pecl install v8js",
+				' | /usr/bin/pecl install v8js-2.1.0",
 			unless  => '/usr/bin/pecl info v8js',
 			require => [
 				Package["libv8-${v8_version}"],


### PR DESCRIPTION
The latest package version 2.1.1 causes provisioning to fail. Fixing it to 2.1.0 solves the issue. This is perhaps a compatibility issue with the version of libv8 installed but we should look at upgrading that separately.